### PR TITLE
Added now as property

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ var lastPushTime = 0;
 // "incremented" by one.
 var lastRandChars = [];
 
-module.exports = function pushid() {
-  var now = new Date().getTime();
+module.exports = function pushid(now) {
+  now = now || new Date().getTime();
   var duplicateTime = (now === lastPushTime);
   lastPushTime = now;
 


### PR DESCRIPTION
From the article:

> There's one caveat to the chronological ordering of push IDs. Since the timestamp is generated client-side, it's at the mercy of the client's local clock, which could be incorrect. We make an attempt to compensate for these ‘skewed’ clocks to some degree. When a Firebase client establishes a connection, the Firebase server sends an accurate timestamp to the client so it can use that to correct its incorrect clock when generating push IDs.

This means that the user of this library should be able to control `now`